### PR TITLE
HDF5 and CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
           packages:
             - gfortran
             - python-dev
+            - libatlas-dev
             - libblas-dev
             - liblapack-dev
             - libopenmpi-dev
             - openmpi-bin
-            - libhdf5-openmpi-dev
             - libboost1.55-all-dev
             - uuid-dev
             - pkg-config
@@ -66,6 +66,12 @@ install:
       cd eigen-eigen-5a0156e40feb
       cmake -H. -Bbuild_eigen -DCMAKE_INSTALL_PREFIX=${PWD}/eigen-3.3.4 >/dev/null 2>&1
       cmake --build build_eigen -- install >/dev/null 2>&1
+      # Download and install HDF5 1.10.1
+      curl -L https://goo.gl/Pvreb8 | tar -xj -C hdf5-1.10.1 --strip-components=1
+      cd hdf5-1.10.1
+      ./configure --prefix=$HOME/Deps/hdf5-1.10.1 --enable-fortran --enable-shared --enable-parallel > /dev/null 2>&1
+      make install > /dev/null 2>&1
+      export LD_LIBRARY_PATH=$HOME/Deps/hdf5-1.10.1/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       pip install --user virtualenv
       cd ${TRAVIS_BUILD_DIR}
     elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
 install:
   - mkdir -p ${HOME}/Deps
   - DEPS=${HOME}/Deps
-  - CMAKE_VERSION=3.7.2
+  - CMAKE_VERSION=3.10.0
   - |
     # Install CMake and Kitware-maintained version of Ninja
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
@@ -67,7 +67,7 @@ install:
       cmake -H. -Bbuild_eigen -DCMAKE_INSTALL_PREFIX=${PWD}/eigen-3.3.4 >/dev/null 2>&1
       cmake --build build_eigen -- install >/dev/null 2>&1
       # Download and install HDF5 1.10.1
-      curl -L https://goo.gl/Pvreb8 | tar -xj #-C hdf5-1.10.1 --strip-components=1
+      curl -L https://goo.gl/Pvreb8 | tar -xj
       cd hdf5-1.10.1
       ./configure --prefix=$HOME/Deps/hdf5-1.10.1 --enable-fortran --enable-shared --enable-parallel > /dev/null 2>&1
       make install > /dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
       cmake -H. -Bbuild_eigen -DCMAKE_INSTALL_PREFIX=${PWD}/eigen-3.3.4 >/dev/null 2>&1
       cmake --build build_eigen -- install >/dev/null 2>&1
       # Download and install HDF5 1.10.1
-      curl -L https://goo.gl/Pvreb8 | tar -xj -C hdf5-1.10.1 --strip-components=1
+      curl -L https://goo.gl/Pvreb8 | tar -xj #-C hdf5-1.10.1 --strip-components=1
       cd hdf5-1.10.1
       ./configure --prefix=$HOME/Deps/hdf5-1.10.1 --enable-fortran --enable-shared --enable-parallel > /dev/null 2>&1
       make install > /dev/null 2>&1

--- a/Chapter03/recipe-07/cxx-example/CMakeLists.txt
+++ b/Chapter03/recipe-07/cxx-example/CMakeLists.txt
@@ -15,7 +15,6 @@ if(TARGET Eigen3::Eigen)
   message(STATUS "Eigen3 version ${EIGEN3_VERSION_STRING} found in ${EIGEN3_INCLUDE_DIR}")
 endif()
 
-find_package(BLAS)
 find_package(LAPACK)
 
 add_executable(linear-algebra linear-algebra.cpp)
@@ -33,10 +32,9 @@ if(BLAS_FOUND AND LAPACK_FOUND)
   target_link_libraries(linear-algebra
     PUBLIC
       Eigen3::Eigen
-      ${BLAS_LIBRARIES}
-      ${LAPACK_LIBRARIES}
     )
 else()
+  message(STATUS "BLAS and LAPACK not found. Using Eigen own functions")
   target_link_libraries(linear-algebra
     PUBLIC
       Eigen3::Eigen

--- a/Chapter03/recipe-09/fortran-example/menu.yml
+++ b/Chapter03/recipe-09/fortran-example/menu.yml
@@ -5,12 +5,12 @@ appveyor:
 drone:
   definitions:
     - CMAKE_Fortran_COMPILER: 'gfortran'
-    - HDF5_ROOT: '$HOME/Deps/hdf5'
+    - HDF5_ROOT: '$HOME/Deps/hdf5-1.10.1'
 
 travis-linux:
   definitions:
     - CMAKE_Fortran_COMPILER: 'gfortran'
-    - HDF5_ROOT: '$HOME/Deps/hdf5'
+    - HDF5_ROOT: '$HOME/Deps/hdf5-1.10.1'
 
 travis-osx:
   definitions:

--- a/Chapter05/recipe-06/fortran-example/menu.yml
+++ b/Chapter05/recipe-06/fortran-example/menu.yml
@@ -5,12 +5,12 @@ appveyor:
 drone:
   definitions:
     - CMAKE_Fortran_COMPILER: 'gfortran'
-    - HDF5_ROOT: '$HOME/Deps/hdf5'
+    - HDF5_ROOT: '$HOME/Deps/hdf5-1.10.1'
 
 travis-linux:
   definitions:
     - CMAKE_Fortran_COMPILER: 'gfortran'
-    - HDF5_ROOT: '$HOME/Deps/hdf5'
+    - HDF5_ROOT: '$HOME/Deps/hdf5-1.10.1'
 
 travis-osx:
   definitions:

--- a/default.nix
+++ b/default.nix
@@ -26,9 +26,7 @@ in
       atlas
       boost
       ccache
-      clang
       clang-tools
-      clang-analyzer
       cmake
       doxygen
       exa


### PR DESCRIPTION
- I managed to download and compile HDF5 1.10.1 with `--enable-fortran`
- I updated to CMake 3.10.0
- The Eigen example is broken. `dgemv_` not found. I don't fully understand what's going on
- The HDF5 exampe relying on Fortran2003 fails because Fortran2003 bindings are not available.

All in all, not a lot of progress I am afraid