### PR TITLE
Get the correct CMake version on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,14 @@ before_install:
 install:
   - mkdir -p ${HOME}/Deps
   - DEPS=${HOME}/Deps
-  - CMAKE_VERSION=3.10.0
   - |
     # Install CMake and Kitware-maintained version of Ninja
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       cd ${DEPS}
-      mkdir -p cmake-${CMAKE_VERSION}
-      curl -L https://goo.gl/dSVHTh | tar -xz -C cmake-${CMAKE_VERSION} --strip-components=1
-      export PATH=$PWD/cmake-${CMAKE_VERSION}/bin:$PATH
-      export LD_LIBRARY_PATH=$PWD/cmake-${CMAKE_VERSION}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      mkdir -p cmake
+      curl -L https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz | tar -xz -C cmake --strip-components=1
+      export PATH=$PWD/cmake/bin:$PATH
+      export LD_LIBRARY_PATH=$PWD/cmake/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       # Get Eigen
       curl -L http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz | tar xz
       cd eigen-eigen-5a0156e40feb

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
       mkdir -p cmake-${CMAKE_VERSION}
       curl -L https://goo.gl/dSVHTh | tar -xz -C cmake-${CMAKE_VERSION} --strip-components=1
       export PATH=$PWD/cmake-${CMAKE_VERSION}/bin:$PATH
-      export LD_LIBARY_PATH=$PWD/cmake-${CMAKE_VERSION}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      export LD_LIBRARY_PATH=$PWD/cmake-${CMAKE_VERSION}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       # Get Eigen
       curl -L http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz | tar xz
       cd eigen-eigen-5a0156e40feb

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
       curl -L https://goo.gl/Pvreb8 | tar -xj
       cd hdf5-1.10.1
       ./configure --prefix=$HOME/Deps/hdf5-1.10.1 --enable-fortran --enable-shared --enable-parallel > /dev/null 2>&1
-      make install > /dev/null 2>&1
+      travis_wait make install > /dev/null 2>&1
       export LD_LIBRARY_PATH=$HOME/Deps/hdf5-1.10.1/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       pip install --user virtualenv
       cd ${TRAVIS_BUILD_DIR}


### PR DESCRIPTION
HDF5 is still a problem since it takes forever to install and sometimes times out Travis.