### PR TITLE
Color output from script

### DIFF
--- a/.scripts/ci_configure_build_test.py
+++ b/.scripts/ci_configure_build_test.py
@@ -67,7 +67,7 @@ def run_command(step,
     skip_predicate: bool(stdout, stderr)
     verbose: bool; if True always print stdout and stderr from command
     """
-    colorama.init()
+    colorama.init(autoreset=True)
     child = subprocess.Popen(command,
                              shell=True,
                              stdout=subprocess.PIPE,
@@ -81,17 +81,16 @@ def run_command(step,
 
     return_code = 0
     if not skip_predicate(stdout, stderr):
-        sys.stdout.write(colorama.Fore.GREEN + colorama.Style.BRIGHT + '  {0} ... '.format(step))
+        sys.stdout.write(colorama.Fore.BLUE + colorama.Style.BRIGHT + '  {0} ... '.format(step))
         if child_return_code == 0:
-            sys.stdout.write('OK\n')
-            print(colorama.Style.RESET_ALL)
+            sys.stdout.write(colorama.Fore.GREEN + colorama.Style.BRIGHT + 'OK\n')
             if verbose:
                 sys.stdout.write(stdout + stderr + '\n')
         else:
             if expect_failure:
-                sys.stdout.write('EXPECTED TO FAIL\n')
+                sys.stdout.write(colorama.Fore.YELLOW + colorama.Style.BRIGHT + 'EXPECTED TO FAIL\n')
             else:
-                sys.stdout.write('FAILED\n')
+                sys.stdout.write(colorama.Fore.RED + colorama.Style.BRIGHT + 'FAILED\n')
                 sys.stderr.write(stdout + stderr + '\n')
                 return_code = child_return_code
         sys.stdout.flush()

--- a/.scripts/ci_configure_build_test.py
+++ b/.scripts/ci_configure_build_test.py
@@ -67,7 +67,7 @@ def run_command(step,
     skip_predicate: bool(stdout, stderr)
     verbose: bool; if True always print stdout and stderr from command
     """
-    colorama.init(autoreset=True)
+    colorama.init()
     child = subprocess.Popen(command,
                              shell=True,
                              stdout=subprocess.PIPE,
@@ -82,15 +82,19 @@ def run_command(step,
     return_code = 0
     if not skip_predicate(stdout, stderr):
         sys.stdout.write(colorama.Fore.BLUE + colorama.Style.BRIGHT + '  {0} ... '.format(step))
+        sys.stdout.write(colorama.Style.RESET_ALL)
         if child_return_code == 0:
             sys.stdout.write(colorama.Fore.GREEN + colorama.Style.BRIGHT + 'OK\n')
+            sys.stdout.write(colorama.Style.RESET_ALL)
             if verbose:
                 sys.stdout.write(stdout + stderr + '\n')
         else:
             if expect_failure:
                 sys.stdout.write(colorama.Fore.YELLOW + colorama.Style.BRIGHT + 'EXPECTED TO FAIL\n')
+                sys.stdout.write(colorama.Style.RESET_ALL)
             else:
                 sys.stdout.write(colorama.Fore.RED + colorama.Style.BRIGHT + 'FAILED\n')
+                sys.stdout.write(colorama.Style.RESET_ALL)
                 sys.stderr.write(stdout + stderr + '\n')
                 return_code = child_return_code
         sys.stdout.flush()

--- a/.scripts/ci_configure_build_test.py
+++ b/.scripts/ci_configure_build_test.py
@@ -8,6 +8,7 @@ import sys
 import datetime
 import time
 import docopt
+import colorama
 
 
 def get_ci_environment():
@@ -66,6 +67,7 @@ def run_command(step,
     skip_predicate: bool(stdout, stderr)
     verbose: bool; if True always print stdout and stderr from command
     """
+    colorama.init()
     child = subprocess.Popen(command,
                              shell=True,
                              stdout=subprocess.PIPE,
@@ -79,9 +81,10 @@ def run_command(step,
 
     return_code = 0
     if not skip_predicate(stdout, stderr):
-        sys.stdout.write('  {0} ... '.format(step))
+        sys.stdout.write(colorama.Fore.GREEN + colorama.Style.BRIGHT + '  {0} ... '.format(step))
         if child_return_code == 0:
             sys.stdout.write('OK\n')
+            print(colorama.Style.RESET_ALL)
             if verbose:
                 sys.stdout.write(stdout + stderr + '\n')
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pyyaml
 pycodestyle
 docopt
+colorama


### PR DESCRIPTION
The `building ... OK` and `configuring ... OK` strings are now printed in bright green. Hopefully it renders OK on all CI platforms and then it can be helpful when `--verbose` is set.