### PR TITLE
use return code instead of skip predicate; fixes #171

### DIFF
--- a/.scripts/ci_configure_build_test.py
+++ b/.scripts/ci_configure_build_test.py
@@ -193,10 +193,7 @@ def main(arguments):
             # build step
             step = 'building'
             command = 'cmake --build . -- {0}'.format(buildflags)
-            # skip if build step produces zero output
-            # in this case we only configure and test
-            # used in chapter 12
-            skip_predicate = lambda stdout, stderr: ('Nothing to be done' in stdout or 'ninja: no work to do.' in stdout)
+            skip_predicate = lambda stdout, stderr: False
             return_code += run_command(step=step,
                                        command=command,
                                        expect_failure=expect_failure,


### PR DESCRIPTION
This fixes the swallowed "building ... OK". No need to skip here since return code is 0 even if there is nothing to build.