### PR TITLE
link also the math target agains blas/lapack; fixes #177

### DIFF
--- a/Chapter03/recipe-04/cxx-example/CMakeLists.txt
+++ b/Chapter03/recipe-04/cxx-example/CMakeLists.txt
@@ -21,6 +21,11 @@ target_include_directories(math
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_BINARY_DIR}
   )
+target_link_libraries(math
+  PRIVATE
+    ${BLAS_LIBRARIES}
+    ${LAPACK_LIBRARIES}
+  )
 
 add_executable(linear-algebra linear-algebra.cpp)
 target_link_libraries(linear-algebra

--- a/Chapter05/recipe-03/cxx-example/CMakeLists.txt
+++ b/Chapter05/recipe-03/cxx-example/CMakeLists.txt
@@ -52,6 +52,11 @@ target_include_directories(math
   INTERFACE
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK
   )
+target_link_libraries(math
+  PRIVATE
+    ${BLAS_LIBRARIES}
+    ${LAPACK_LIBRARIES}
+  )
 
 add_executable(linear-algebra linear-algebra.cpp)
 target_link_libraries(linear-algebra

--- a/Chapter05/recipe-04/cxx-example/deps/CMakeLists.txt
+++ b/Chapter05/recipe-04/cxx-example/deps/CMakeLists.txt
@@ -38,4 +38,9 @@ target_include_directories(math
   INTERFACE
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK
   )
+target_link_libraries(math
+  PRIVATE
+    ${BLAS_LIBRARIES}
+    ${LAPACK_LIBRARIES}
+  )
 add_dependencies(math BLAS_LAPACK_wrappers)


### PR DESCRIPTION
This restores the math recipes but I am not sure this is the right solution. I have observed that math target is not linked against blas/lapack. Please double-check whether the solution is really what we want to do here.