### PR TITLE
Do not use -std=f2003 flag

### DIFF
--- a/Chapter06/recipe-01/fortran-example/CMakeLists.txt
+++ b/Chapter06/recipe-01/fortran-example/CMakeLists.txt
@@ -28,10 +28,6 @@ string(TIMESTAMP _configuration_time "%Y-%m-%d %H:%M:%S [UTC]" UTC)
 configure_file(print_info.c.in print_info.c @ONLY)
 
 add_executable(hello-world hello-world.f90)
-target_compile_options(hello-world
-  PUBLIC
-    -std=f2003
-  )
 target_sources(hello-world
   PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/print_info.c

--- a/Chapter06/recipe-02/fortran-example/CMakeLists.txt
+++ b/Chapter06/recipe-02/fortran-example/CMakeLists.txt
@@ -58,10 +58,6 @@ add_custom_target(build_info
   )
 
 add_executable(hello-world hello-world.f90)
-target_compile_options(hello-world
-  PUBLIC
-    -std=f2003
-  )
 target_sources(hello-world
   PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/print_info.c

--- a/Chapter06/recipe-03/fortran-example/CMakeLists.txt
+++ b/Chapter06/recipe-03/fortran-example/CMakeLists.txt
@@ -40,10 +40,6 @@ add_custom_target(build_info
   )
 
 add_executable(hello-world hello-world.f90)
-target_compile_options(hello-world
-  PUBLIC
-    -std=f2003
-  )
 target_sources(hello-world
   PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/print_info.c


### PR DESCRIPTION
This should fix some of the CI issues. In principle necessary. In practice tricky to enforce without checking whether the compiler has the flag or not. Dropping it, for the moment, since all compilers seem to have `iso_c_binding` anyway.