### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/Chapter03/recipe-04/cxx-example/CMakeLists.txt
+++ b/Chapter03/recipe-04/cxx-example/CMakeLists.txt
@@ -22,16 +22,12 @@ target_include_directories(math
     ${PROJECT_BINARY_DIR}
   )
 target_link_libraries(math
-  PRIVATE
-    ${BLAS_LIBRARIES}
+  PUBLIC
     ${LAPACK_LIBRARIES}
   )
 
 add_executable(linear-algebra linear-algebra.cpp)
 target_link_libraries(linear-algebra
-  PUBLIC
-    ${BLAS_LIBRARIES}
-    ${LAPACK_LIBRARIES}
   PRIVATE
     math
   )


### PR DESCRIPTION
- Linking against LAPACK will also pull in BLAS
- Properly set visibility of `target_link_libraries` for the `math` target. In this way BLAS/LAPACK are properly picked up when linking `linear-algebra` against `math`.