### PR TITLE
rm orphaned broken symlinks

### DIFF
--- a/Chapter04/recipe-02/cxx-example/menu.yml
+++ b/Chapter04/recipe-02/cxx-example/menu.yml
@@ -1,1 +1,0 @@
-../../recipe-01/cxx-example/menu.yml

--- a/Chapter04/recipe-03/cxx-example/menu.yml
+++ b/Chapter04/recipe-03/cxx-example/menu.yml
@@ -1,1 +1,0 @@
-../../recipe-01/cxx-example/menu.yml

--- a/Chapter04/recipe-04/cxx-example/menu.yml
+++ b/Chapter04/recipe-04/cxx-example/menu.yml
@@ -1,1 +1,0 @@
-../../recipe-01/cxx-example/menu.yml

--- a/Chapter06/recipe-07/cxx-example/menu.yml
+++ b/Chapter06/recipe-07/cxx-example/menu.yml
@@ -1,1 +1,0 @@
-../../recipe-06/cxx-example/menu.yml


### PR DESCRIPTION
I forgot this when refactoring for the global menu.yml.