### PR TITLE
Use imported targets

### DIFF
--- a/Chapter03/recipe-10/cxx-example/CMakeLists.txt
+++ b/Chapter03/recipe-10/cxx-example/CMakeLists.txt
@@ -7,17 +7,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(PkgConfig REQUIRED QUIET)
-pkg_search_module(UUID REQUIRED uuid)
+pkg_search_module(UUID REQUIRED uuid IMPORTED_TARGET)
 if(UUID_FOUND)
   message(STATUS "Found libuuid")
 endif()
 
 add_executable(use-uuid use-uuid.cpp)
-target_include_directories(use-uuid
-  PUBLIC
-    ${UUID_INCLUDE_DIRS}
-  )
-target_link_libraries(use-uuid
-  PUBLIC
-    ${UUID_LIBRARIES}
-  )
+target_link_libraries(use-uuid PkgConfig::UUID)

--- a/Chapter04/recipe-04/cxx-example/CMakeLists.txt
+++ b/Chapter04/recipe-04/cxx-example/CMakeLists.txt
@@ -21,23 +21,13 @@ find_package(Boost 1.54 REQUIRED COMPONENTS unit_test_framework)
 
 add_executable(cpp_test test.cpp)
 
-target_include_directories(
-  cpp_test
-  PRIVATE
-  ${Boost_INCLUDE_DIRS}
-  )
+target_link_libraries(cpp_test sum_integers Boost::unit_test_framework)
 
 # avoid undefined reference to "main" in test.cpp
 target_compile_definitions(
   cpp_test
   PRIVATE
   -DBOOST_TEST_DYN_LINK
-  )
-
-target_link_libraries(
-  cpp_test
-  sum_integers
-  ${Boost_LIBRARIES}
   )
 
 enable_testing()


### PR DESCRIPTION
I think that when it's possible you should really prefer the use of imported targets compared to legacy CMake variables definitions for lib, includes, flags etc...

Imported targets convey all what you need in a concise way.

This pull request shows 2 examples of use:
 - one for Boost
 - one for PkgConfig

both these find modules defines imported target.