### PR TITLE
chapter 15 (cdash recipes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,10 @@
 
 ### [Chapter 15: Testing Dashboards](chapter-15/README.md)
 
+- [Deploying tests to the CDash dashboard](chapter-15/recipe-01/README.md)
+- [Reporting test coverage to the CDash dashboard](chapter-15/recipe-02/README.md)
+- [Using the AddressSanitizer and reporting memory defects to CDash](chapter-15/recipe-03/README.md)
+- [Using the ThreadSanitizer and reporting data races to CDash](chapter-15/recipe-04/README.md)
+
+
 ### [Chapter 16: Porting a Project to CMake](https://github.com/bast/vim/compare/master...cmake-support)

--- a/chapter-15/README.md
+++ b/chapter-15/README.md
@@ -1,2 +1,6 @@
 # Chapter 15: Testing Dashboards
 
+- [Deploying tests to the CDash dashboard](recipe-01/README.md)
+- [Reporting test coverage to the CDash dashboard](recipe-02/README.md)
+- [Using the AddressSanitizer and reporting memory defects to CDash](recipe-03/README.md)
+- [Using the ThreadSanitizer and reporting data races to CDash](recipe-04/README.md)

--- a/chapter-15/recipe-01/README.md
+++ b/chapter-15/recipe-01/README.md
@@ -1,0 +1,5 @@
+# Deploying tests to the CDash dashboard
+
+Abstract to be written ...
+
+- [cxx-example](cxx-example/)

--- a/chapter-15/recipe-01/cxx-example/CMakeLists.txt
+++ b/chapter-15/recipe-01/cxx-example/CMakeLists.txt
@@ -1,0 +1,21 @@
+# set minimum cmake version
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+# project name and language
+project(recipe-02 LANGUAGES CXX)
+
+# require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# process src/CMakeLists.txt
+add_subdirectory(src)
+
+enable_testing()
+
+# allow to report to a cdash dashboard
+include(CTest)
+
+# process tests/CMakeLists.txt
+add_subdirectory(tests)

--- a/chapter-15/recipe-01/cxx-example/CTestConfig.cmake
+++ b/chapter-15/recipe-01/cxx-example/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=cmake-cookbook")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/chapter-15/recipe-01/cxx-example/menu.yml
+++ b/chapter-15/recipe-01/cxx-example/menu.yml
@@ -1,0 +1,2 @@
+targets:
+  - test

--- a/chapter-15/recipe-01/cxx-example/src/CMakeLists.txt
+++ b/chapter-15/recipe-01/cxx-example/src/CMakeLists.txt
@@ -1,0 +1,21 @@
+# example library
+add_library(sum_integers "")
+
+target_sources(
+  sum_integers
+  PRIVATE
+    sum_integers.cpp
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/sum_integers.hpp
+  )
+
+target_include_directories(
+  sum_integers
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+  )
+
+# main code
+add_executable(sum_up main.cpp)
+
+target_link_libraries(sum_up sum_integers)

--- a/chapter-15/recipe-01/cxx-example/src/main.cpp
+++ b/chapter-15/recipe-01/cxx-example/src/main.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <vector>
+
+#include "sum_integers.hpp"
+
+// we assume all arguments are integers and we sum them up
+// for simplicity we do not verify the type of arguments
+int main(int argc, char *argv[]) {
+
+  std::vector<int> integers;
+  for (auto i = 1; i < argc; i++) {
+    integers.push_back(atoi(argv[i]));
+  }
+  auto sum = sum_integers(integers);
+
+  std::cout << sum << std::endl;
+}

--- a/chapter-15/recipe-01/cxx-example/src/main.cpp
+++ b/chapter-15/recipe-01/cxx-example/src/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <vector>
+#include <string>
 
 #include "sum_integers.hpp"
 
@@ -9,7 +10,7 @@ int main(int argc, char *argv[]) {
 
   std::vector<int> integers;
   for (auto i = 1; i < argc; i++) {
-    integers.push_back(atoi(argv[i]));
+    integers.push_back(std::stoi(argv[i]));
   }
   auto sum = sum_integers(integers);
 

--- a/chapter-15/recipe-01/cxx-example/src/sum_integers.cpp
+++ b/chapter-15/recipe-01/cxx-example/src/sum_integers.cpp
@@ -1,0 +1,11 @@
+#include "sum_integers.hpp"
+
+#include <vector>
+
+int sum_integers(const std::vector<int> integers) {
+  auto sum = 0;
+  for (auto i : integers) {
+    sum += i;
+  }
+  return sum;
+}

--- a/chapter-15/recipe-01/cxx-example/src/sum_integers.hpp
+++ b/chapter-15/recipe-01/cxx-example/src/sum_integers.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <vector>
+
+int sum_integers(const std::vector<int> integers);

--- a/chapter-15/recipe-01/cxx-example/tests/CMakeLists.txt
+++ b/chapter-15/recipe-01/cxx-example/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(test_short test_short.cpp)
+target_link_libraries(test_short sum_integers)
+
+add_executable(test_long test_long.cpp)
+target_link_libraries(test_long sum_integers)
+
+add_test(
+  NAME
+    test_short
+  COMMAND
+    ${PROJECT_BINARY_DIR}/tests/test_short
+  )
+
+add_test(
+  NAME
+    test_long
+  COMMAND
+    ${PROJECT_BINARY_DIR}/tests/test_long
+  )

--- a/chapter-15/recipe-01/cxx-example/tests/test_long.cpp
+++ b/chapter-15/recipe-01/cxx-example/tests/test_long.cpp
@@ -1,0 +1,16 @@
+#include "sum_integers.hpp"
+
+#include <numeric>
+#include <vector>
+
+int main() {
+  // creates vector {1, 2, 3, ..., 999, 1000}
+  std::vector<int> integers(1000);
+  std::iota(integers.begin(), integers.end(), 1);
+
+  if (sum_integers(integers) == 500500) {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/chapter-15/recipe-01/cxx-example/tests/test_short.cpp
+++ b/chapter-15/recipe-01/cxx-example/tests/test_short.cpp
@@ -1,0 +1,13 @@
+#include "sum_integers.hpp"
+
+#include <vector>
+
+int main() {
+  auto integers = {1, 2, 3, 4, 5};
+
+  if (sum_integers(integers) == 15) {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/chapter-15/recipe-01/title.txt
+++ b/chapter-15/recipe-01/title.txt
@@ -1,0 +1,1 @@
+Deploying tests to the CDash dashboard

--- a/chapter-15/recipe-02/README.md
+++ b/chapter-15/recipe-02/README.md
@@ -1,0 +1,5 @@
+# Reporting test coverage to the CDash dashboard
+
+Abstract to be written ...
+
+- [cxx-example](cxx-example/)

--- a/chapter-15/recipe-02/cxx-example/CMakeLists.txt
+++ b/chapter-15/recipe-02/cxx-example/CMakeLists.txt
@@ -1,0 +1,21 @@
+# set minimum cmake version
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+# project name and language
+project(recipe-02 LANGUAGES CXX)
+
+# require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# process src/CMakeLists.txt
+add_subdirectory(src)
+
+enable_testing()
+
+# allow to report to a cdash dashboard
+include(CTest)
+
+# process tests/CMakeLists.txt
+add_subdirectory(tests)

--- a/chapter-15/recipe-02/cxx-example/CTestConfig.cmake
+++ b/chapter-15/recipe-02/cxx-example/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=cmake-cookbook")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/chapter-15/recipe-02/cxx-example/menu.yml
+++ b/chapter-15/recipe-02/cxx-example/menu.yml
@@ -1,0 +1,2 @@
+targets:
+  - test

--- a/chapter-15/recipe-02/cxx-example/src/CMakeLists.txt
+++ b/chapter-15/recipe-02/cxx-example/src/CMakeLists.txt
@@ -1,0 +1,40 @@
+# example library
+add_library(sum_integers "")
+
+target_sources(
+  sum_integers
+  PRIVATE
+    sum_integers.cpp
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/sum_integers.hpp
+  )
+
+target_include_directories(
+  sum_integers
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+  )
+
+option(ENABLE_COVERAGE "Enable coverage" ON)
+
+if(ENABLE_COVERAGE)
+  if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    target_compile_options(
+      sum_integers
+      PUBLIC
+        -fprofile-arcs -ftest-coverage -g
+      )
+    target_link_libraries(
+      sum_integers
+      PUBLIC
+        gcov
+      )
+  else()
+    message(WARNING "Coverage not supported for this compiler")
+  endif()
+endif()
+
+# main code
+add_executable(sum_up main.cpp)
+
+target_link_libraries(sum_up sum_integers)

--- a/chapter-15/recipe-02/cxx-example/src/main.cpp
+++ b/chapter-15/recipe-02/cxx-example/src/main.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <vector>
+
+#include "sum_integers.hpp"
+
+// we assume all arguments are integers and we sum them up
+// for simplicity we do not verify the type of arguments
+int main(int argc, char *argv[]) {
+
+  std::vector<int> integers;
+  for (auto i = 1; i < argc; i++) {
+    integers.push_back(atoi(argv[i]));
+  }
+  auto sum = sum_integers(integers);
+
+  std::cout << sum << std::endl;
+}

--- a/chapter-15/recipe-02/cxx-example/src/main.cpp
+++ b/chapter-15/recipe-02/cxx-example/src/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <vector>
+#include <string>
 
 #include "sum_integers.hpp"
 
@@ -9,7 +10,7 @@ int main(int argc, char *argv[]) {
 
   std::vector<int> integers;
   for (auto i = 1; i < argc; i++) {
-    integers.push_back(atoi(argv[i]));
+    integers.push_back(std::stoi(argv[i]));
   }
   auto sum = sum_integers(integers);
 

--- a/chapter-15/recipe-02/cxx-example/src/sum_integers.cpp
+++ b/chapter-15/recipe-02/cxx-example/src/sum_integers.cpp
@@ -1,0 +1,19 @@
+#include "sum_integers.hpp"
+
+#include <vector>
+
+int sum_integers(const std::vector<int> integers) {
+  auto sum = 0;
+  for (auto i : integers) {
+    sum += i;
+  }
+  return sum;
+}
+
+int sum_integers_unused(const std::vector<int> integers) {
+  auto sum = 0;
+  for (auto i : integers) {
+    sum += i;
+  }
+  return sum;
+}

--- a/chapter-15/recipe-02/cxx-example/src/sum_integers.hpp
+++ b/chapter-15/recipe-02/cxx-example/src/sum_integers.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <vector>
+
+int sum_integers(const std::vector<int> integers);

--- a/chapter-15/recipe-02/cxx-example/tests/CMakeLists.txt
+++ b/chapter-15/recipe-02/cxx-example/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(test_short test_short.cpp)
+target_link_libraries(test_short sum_integers)
+
+add_executable(test_long test_long.cpp)
+target_link_libraries(test_long sum_integers)
+
+add_test(
+  NAME
+    test_short
+  COMMAND
+    ${PROJECT_BINARY_DIR}/tests/test_short
+  )
+
+add_test(
+  NAME
+    test_long
+  COMMAND
+    ${PROJECT_BINARY_DIR}/tests/test_long
+  )

--- a/chapter-15/recipe-02/cxx-example/tests/test_long.cpp
+++ b/chapter-15/recipe-02/cxx-example/tests/test_long.cpp
@@ -1,0 +1,16 @@
+#include "sum_integers.hpp"
+
+#include <numeric>
+#include <vector>
+
+int main() {
+  // creates vector {1, 2, 3, ..., 999, 1000}
+  std::vector<int> integers(1000);
+  std::iota(integers.begin(), integers.end(), 1);
+
+  if (sum_integers(integers) == 500500) {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/chapter-15/recipe-02/cxx-example/tests/test_short.cpp
+++ b/chapter-15/recipe-02/cxx-example/tests/test_short.cpp
@@ -1,0 +1,13 @@
+#include "sum_integers.hpp"
+
+#include <vector>
+
+int main() {
+  auto integers = {1, 2, 3, 4, 5};
+
+  if (sum_integers(integers) == 15) {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/chapter-15/recipe-02/title.txt
+++ b/chapter-15/recipe-02/title.txt
@@ -1,0 +1,1 @@
+Reporting test coverage to the CDash dashboard

--- a/chapter-15/recipe-03/README.md
+++ b/chapter-15/recipe-03/README.md
@@ -1,0 +1,6 @@
+# Using the AddressSanitizer and reporting memory defects to CDash
+
+Abstract to be written ...
+
+- [cxx-example](cxx-example/)
+- [fortran-example](fortran-example/)

--- a/chapter-15/recipe-03/cxx-example/CMakeLists.txt
+++ b/chapter-15/recipe-03/cxx-example/CMakeLists.txt
@@ -1,0 +1,21 @@
+# set minimum cmake version
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+# project name and language
+project(recipe-03 LANGUAGES CXX)
+
+# require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# process src/CMakeLists.txt
+add_subdirectory(src)
+
+enable_testing()
+
+# allow to report to a cdash dashboard
+include(CTest)
+
+# process tests/CMakeLists.txt
+add_subdirectory(tests)

--- a/chapter-15/recipe-03/cxx-example/CTestConfig.cmake
+++ b/chapter-15/recipe-03/cxx-example/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=cmake-cookbook")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/chapter-15/recipe-03/cxx-example/dashboard.cmake
+++ b/chapter-15/recipe-03/cxx-example/dashboard.cmake
@@ -1,0 +1,29 @@
+set(CTEST_PROJECT_NAME "example")
+set(CTEST_SITE "localhost")
+set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
+
+set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}")
+set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+include(ProcessorCount)
+ProcessorCount(N)
+if(NOT N EQUAL 0)
+  set(CTEST_BUILD_FLAGS -j${N})
+  set(ctest_test_args ${ctest_test_args} PARALLEL_LEVEL ${N})
+endif()
+
+ctest_start(Experimental)
+
+ctest_configure(
+  OPTIONS
+    -DENABLE_ASAN:BOOL=ON
+  )
+
+ctest_build()
+ctest_test()
+
+set(CTEST_MEMORYCHECK_TYPE "AddressSanitizer")
+ctest_memcheck()
+
+ctest_submit()

--- a/chapter-15/recipe-03/cxx-example/dashboard.cmake
+++ b/chapter-15/recipe-03/cxx-example/dashboard.cmake
@@ -4,6 +4,9 @@ set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
 set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}")
 set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
+
+# for more portable test script this can also be provided via command line:
+# ctest -S dashboard.cmake -D CTEST_CMAKE_GENERATOR="Unix Makefiles"
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 include(ProcessorCount)

--- a/chapter-15/recipe-03/cxx-example/menu.yml
+++ b/chapter-15/recipe-03/cxx-example/menu.yml
@@ -1,0 +1,2 @@
+targets:
+  - test

--- a/chapter-15/recipe-03/cxx-example/src/CMakeLists.txt
+++ b/chapter-15/recipe-03/cxx-example/src/CMakeLists.txt
@@ -1,0 +1,34 @@
+add_library(buggy "")
+
+target_sources(
+  buggy
+  PRIVATE
+    buggy.cpp
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/buggy.hpp
+  )
+
+target_include_directories(
+  buggy
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+  )
+
+option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+
+if(ENABLE_ASAN)
+  if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    target_compile_options(
+      buggy
+      PUBLIC
+        -g -O1 -fsanitize=address -fno-omit-frame-pointer
+      )
+    target_link_libraries(
+      buggy
+      PUBLIC
+        asan
+      )
+  else()
+    message(WARNING "AddressSanitizer not supported for this compiler")
+  endif()
+endif()

--- a/chapter-15/recipe-03/cxx-example/src/buggy.cpp
+++ b/chapter-15/recipe-03/cxx-example/src/buggy.cpp
@@ -1,0 +1,31 @@
+#include "buggy.hpp"
+
+#include <iostream>
+
+int function_leaky() {
+
+  double *my_array = new double[1000];
+
+  // do some work ...
+
+  // we forget to deallocate the array
+  // delete[] my_array;
+
+  return 0;
+}
+
+int function_use_after_free() {
+
+  double *another_array = new double[1000];
+
+  // do some work ...
+
+  // deallocate it, good!
+  delete[] another_array;
+
+  // however, we accidentally use the array
+  // after it has been deallocated
+  std::cout << "not sure what we get: " << another_array[123] << std::endl;
+
+  return 0;
+}

--- a/chapter-15/recipe-03/cxx-example/src/buggy.hpp
+++ b/chapter-15/recipe-03/cxx-example/src/buggy.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+int function_leaky();
+int function_use_after_free();

--- a/chapter-15/recipe-03/cxx-example/tests/CMakeLists.txt
+++ b/chapter-15/recipe-03/cxx-example/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+foreach(_test leaky use_after_free)
+  add_executable(${_test} ${_test}.cpp)
+  target_link_libraries(${_test} buggy)
+
+  add_test(
+    NAME
+      ${_test}
+    COMMAND
+      ${PROJECT_BINARY_DIR}/tests/${_test}
+    )
+endforeach()

--- a/chapter-15/recipe-03/cxx-example/tests/leaky.cpp
+++ b/chapter-15/recipe-03/cxx-example/tests/leaky.cpp
@@ -1,0 +1,6 @@
+#include "buggy.hpp"
+
+int main() {
+  int return_code = function_leaky();
+  return return_code;
+}

--- a/chapter-15/recipe-03/cxx-example/tests/use_after_free.cpp
+++ b/chapter-15/recipe-03/cxx-example/tests/use_after_free.cpp
@@ -1,0 +1,6 @@
+#include "buggy.hpp"
+
+int main() {
+  int return_code = function_use_after_free();
+  return return_code;
+}

--- a/chapter-15/recipe-03/fortran-example/CMakeLists.txt
+++ b/chapter-15/recipe-03/fortran-example/CMakeLists.txt
@@ -1,0 +1,21 @@
+# set minimum cmake version
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+# project name and language
+project(recipe-03 LANGUAGES Fortran)
+
+# require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# process src/CMakeLists.txt
+add_subdirectory(src)
+
+enable_testing()
+
+# allow to report to a cdash dashboard
+include(CTest)
+
+# process tests/CMakeLists.txt
+add_subdirectory(tests)

--- a/chapter-15/recipe-03/fortran-example/CTestConfig.cmake
+++ b/chapter-15/recipe-03/fortran-example/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=cmake-cookbook")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/chapter-15/recipe-03/fortran-example/dashboard.cmake
+++ b/chapter-15/recipe-03/fortran-example/dashboard.cmake
@@ -1,0 +1,29 @@
+set(CTEST_PROJECT_NAME "example")
+set(CTEST_SITE "localhost")
+set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
+
+set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}")
+set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+include(ProcessorCount)
+ProcessorCount(N)
+if(NOT N EQUAL 0)
+  set(CTEST_BUILD_FLAGS -j${N})
+  set(ctest_test_args ${ctest_test_args} PARALLEL_LEVEL ${N})
+endif()
+
+ctest_start(Experimental)
+
+ctest_configure(
+  OPTIONS
+    -DENABLE_ASAN:BOOL=ON
+  )
+
+ctest_build()
+ctest_test()
+
+set(CTEST_MEMORYCHECK_TYPE "AddressSanitizer")
+ctest_memcheck()
+
+ctest_submit()

--- a/chapter-15/recipe-03/fortran-example/dashboard.cmake
+++ b/chapter-15/recipe-03/fortran-example/dashboard.cmake
@@ -4,6 +4,9 @@ set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
 set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}")
 set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
+
+# for more portable test script this can also be provided via command line:
+# ctest -S dashboard.cmake -D CTEST_CMAKE_GENERATOR="Unix Makefiles"
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 include(ProcessorCount)

--- a/chapter-15/recipe-03/fortran-example/menu.yml
+++ b/chapter-15/recipe-03/fortran-example/menu.yml
@@ -1,0 +1,10 @@
+targets:
+  - test
+
+travis-linux:
+  failing_generators:
+    - 'Ninja'
+
+travis-osx:
+  failing_generators:
+    - 'Ninja'

--- a/chapter-15/recipe-03/fortran-example/src/CMakeLists.txt
+++ b/chapter-15/recipe-03/fortran-example/src/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_library(buggy "")
+
+target_sources(
+  buggy
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/buggy.f90
+  )
+
+option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+
+if(ENABLE_ASAN)
+  if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+    target_compile_options(
+      buggy
+      PUBLIC
+        -g -fsanitize=address
+      )
+    target_link_libraries(
+      buggy
+      PUBLIC
+        asan
+      )
+  else()
+    message(WARNING "AddressSanitizer not supported for this compiler")
+  endif()
+endif()

--- a/chapter-15/recipe-03/fortran-example/src/buggy.f90
+++ b/chapter-15/recipe-03/fortran-example/src/buggy.f90
@@ -1,0 +1,24 @@
+module buggy
+
+  implicit none
+
+  public function_leaky
+
+  private
+
+contains
+
+  integer function function_leaky()
+    real(8), pointer :: my_array(:)
+    allocate(my_array(1000))
+    ! accidentally allocate twice
+    allocate(my_array(1000))
+
+    ! do some work ...
+
+    deallocate(my_array)
+
+    function_leaky = 0
+  end function
+
+end module

--- a/chapter-15/recipe-03/fortran-example/tests/CMakeLists.txt
+++ b/chapter-15/recipe-03/fortran-example/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(leaky leaky.f90)
+target_link_libraries(leaky buggy)
+
+add_test(
+  NAME
+    leaky
+  COMMAND
+    ${PROJECT_BINARY_DIR}/tests/leaky
+  )

--- a/chapter-15/recipe-03/fortran-example/tests/leaky.f90
+++ b/chapter-15/recipe-03/fortran-example/tests/leaky.f90
@@ -1,0 +1,8 @@
+program test
+  use buggy, only: function_leaky
+  implicit none
+
+  if (function_leaky() /= 0) then
+    error stop
+  end if
+end program

--- a/chapter-15/recipe-03/fortran-example/tests/out_of_bounds.f90
+++ b/chapter-15/recipe-03/fortran-example/tests/out_of_bounds.f90
@@ -1,0 +1,8 @@
+program test
+  use buggy, only: function_out_of_bounds
+  implicit none
+
+  if (function_out_of_bounds() /= 0) then
+    error stop
+  end if
+end program

--- a/chapter-15/recipe-03/title.txt
+++ b/chapter-15/recipe-03/title.txt
@@ -1,0 +1,1 @@
+Using the AddressSanitizer and reporting memory defects to CDash

--- a/chapter-15/recipe-04/README.md
+++ b/chapter-15/recipe-04/README.md
@@ -1,0 +1,5 @@
+# Using the ThreadSanitizer and reporting data races to CDash
+
+Abstract to be written ...
+
+- [cxx-example](cxx-example/)

--- a/chapter-15/recipe-04/cxx-example/CMakeLists.txt
+++ b/chapter-15/recipe-04/cxx-example/CMakeLists.txt
@@ -8,13 +8,14 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(OpenMP REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(example example.cpp)
+
 target_link_libraries(
   example
   PUBLIC
-    OpenMP::OpenMP_CXX
+    Threads::Threads
   )
 
 option(ENABLE_TSAN "Enable ThreadSanitizer" OFF)

--- a/chapter-15/recipe-04/cxx-example/CMakeLists.txt
+++ b/chapter-15/recipe-04/cxx-example/CMakeLists.txt
@@ -1,0 +1,49 @@
+# set minimum cmake version
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+
+# project name and language
+project(recipe-04 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(OpenMP REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(
+  example
+  PUBLIC
+    OpenMP::OpenMP_CXX
+  )
+
+option(ENABLE_TSAN "Enable ThreadSanitizer" OFF)
+
+if(ENABLE_TSAN)
+  if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    target_compile_options(
+      example
+      PUBLIC
+        -g -O1 -fsanitize=thread -fno-omit-frame-pointer -fPIC
+      )
+    target_link_libraries(
+      example
+      PUBLIC
+        tsan
+      )
+  else()
+    message(WARNING "ThreadSanitizer not supported for this compiler")
+  endif()
+endif()
+
+enable_testing()
+
+# allow to report to a cdash dashboard
+include(CTest)
+
+add_test(
+  NAME
+    example
+  COMMAND
+    ${PROJECT_BINARY_DIR}/example
+  )

--- a/chapter-15/recipe-04/cxx-example/CTestConfig.cmake
+++ b/chapter-15/recipe-04/cxx-example/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=cmake-cookbook")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/chapter-15/recipe-04/cxx-example/dashboard.cmake
+++ b/chapter-15/recipe-04/cxx-example/dashboard.cmake
@@ -1,0 +1,29 @@
+set(CTEST_PROJECT_NAME "example")
+set(CTEST_SITE "localhost")
+set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
+
+set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}")
+set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+include(ProcessorCount)
+ProcessorCount(N)
+if(NOT N EQUAL 0)
+  set(CTEST_BUILD_FLAGS -j${N})
+  set(ctest_test_args ${ctest_test_args} PARALLEL_LEVEL ${N})
+endif()
+
+ctest_start(Experimental)
+
+ctest_configure(
+  OPTIONS
+    -DENABLE_TSAN:BOOL=ON
+  )
+
+ctest_build()
+ctest_test()
+
+set(CTEST_MEMORYCHECK_TYPE "ThreadSanitizer")
+ctest_memcheck()
+
+ctest_submit()

--- a/chapter-15/recipe-04/cxx-example/dashboard.cmake
+++ b/chapter-15/recipe-04/cxx-example/dashboard.cmake
@@ -4,6 +4,9 @@ set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
 set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}")
 set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
+
+# for more portable test script this can also be provided via command line:
+# ctest -S dashboard.cmake -D CTEST_CMAKE_GENERATOR="Unix Makefiles"
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 include(ProcessorCount)

--- a/chapter-15/recipe-04/cxx-example/example.cpp
+++ b/chapter-15/recipe-04/cxx-example/example.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+static const int num_threads = 16;
+
+void increase(int i, int &s) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::cout << "thread " << i << " increases " << s++ << std::endl;
+}
+
+int main() {
+    std::thread t[num_threads];
+
+    int s = 0;
+
+    // start threads
+    for (auto i = 0; i < num_threads; i++) {
+        t[i] = std::thread(increase, i, std::ref(s));
+    }
+
+    // join threads with main thread
+    for (auto i = 0; i < num_threads; i++) {
+        t[i].join();
+    }
+
+    std::cout << "final s: " << s << std::endl;
+
+    return 0;
+}

--- a/chapter-15/recipe-04/cxx-example/menu.yml
+++ b/chapter-15/recipe-04/cxx-example/menu.yml
@@ -1,0 +1,5 @@
+# OpenMP does not work with clang
+travis-osx:
+  failing_generators:
+    - 'Unix Makefiles'
+    - 'Ninja'

--- a/chapter-15/recipe-04/title.txt
+++ b/chapter-15/recipe-04/title.txt
@@ -1,0 +1,1 @@
+Using the ThreadSanitizer and reporting data races to CDash

--- a/contributing/generate-readmes.py
+++ b/contributing/generate-readmes.py
@@ -92,7 +92,8 @@ def generate_main_readme(directory_of_this_script,
                                                                 recipe))
     
         # chapter 16 is hard-coded
-        f.write('### [Chapter 16: Porting a Project to CMake](https://github.com/bast/vim/compare/master...cmake-support)\n')
+        # since it points to an outside diff
+        f.write('\n\n### [Chapter 16: Porting a Project to CMake](https://github.com/bast/vim/compare/master...cmake-support)\n')
 
 
 def locate_chapters_and_recipes(directory_of_this_script):


### PR DESCRIPTION
The first deploys tests to CDash. The second recipe builds on top of it and also reports test coverage. Both are C++ only and we may consider adding Fortran examples.