### PR TITLE
No need to add an extra TID when TLL is using properly defined import…

### DIFF
--- a/chapter-07/recipe-02/cxx-example/src/CMakeLists.txt
+++ b/chapter-07/recipe-02/cxx-example/src/CMakeLists.txt
@@ -5,11 +5,7 @@ project(recipe-02_core LANGUAGES CXX)
 find_package(Boost 1.61 REQUIRED COMPONENTS filesystem)
 
 add_executable(path-info path-info.cpp)
-target_include_directories(path-info
-  SYSTEM
-  PUBLIC
-    Boost::filesystem
-  )
+
 target_link_libraries(path-info
   PUBLIC
     Boost::filesystem


### PR DESCRIPTION
No need to add an extra TID when TLL is using properly defined imported lib
This link to issue https://github.com/bast/cmake-recipes/issues/301
