### PR TITLE
Do not show globbing in recipes since this is not a recommended pattern

### DIFF
--- a/chapter-01/recipe-07/cxx-example/CMakeLists.txt
+++ b/chapter-01/recipe-07/cxx-example/CMakeLists.txt
@@ -10,9 +10,18 @@ message("C++ compiler flags, release mode: ${CMAKE_CXX_FLAGS_RELEASE}")
 message("C++ compiler flags, release with debug info mode: ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 message("C++ compiler flags, minimal release mode: ${CMAKE_CXX_FLAGS_MINSIZEREL}")
 
-file(GLOB _sources geometry_*)
-
-add_library(geometry STATIC ${_sources})
+add_library(
+  geometry
+  STATIC
+  geometry_circle.cpp
+  geometry_circle.hpp
+  geometry_polygon.cpp
+  geometry_polygon.hpp
+  geometry_rhombus.cpp
+  geometry_rhombus.hpp
+  geometry_square.cpp
+  geometry_square.hpp
+  )
 
 add_executable(compute-areas compute-areas.cpp)
 target_link_libraries(compute-areas geometry)

--- a/chapter-01/recipe-08/cxx-example/CMakeLists.txt
+++ b/chapter-01/recipe-08/cxx-example/CMakeLists.txt
@@ -8,14 +8,24 @@ message("C++ compiler flags: ${CMAKE_CXX_FLAGS}")
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-# list sources by globbing
-file(GLOB _sources geometry_*)
-
 list(APPEND flags "-fPIC" "-Wall")
 if(NOT WIN32)
   list(APPEND flags "-Wextra" "-Wpedantic")
 endif()
-add_library(geometry STATIC ${_sources})
+
+add_library(
+  geometry
+  STATIC
+  geometry_circle.cpp
+  geometry_circle.hpp
+  geometry_polygon.cpp
+  geometry_polygon.hpp
+  geometry_rhombus.cpp
+  geometry_rhombus.hpp
+  geometry_square.cpp
+  geometry_square.hpp
+  )
+
 target_compile_options(geometry
   PRIVATE
     ${flags}

--- a/chapter-01/recipe-09/fortran-example/CMakeLists.txt
+++ b/chapter-01/recipe-09/fortran-example/CMakeLists.txt
@@ -4,13 +4,18 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 # project name and language
 project(recipe-09 LANGUAGES Fortran)
 
-# list sources by globbing
-file(GLOB _sources geometry_*)
-
-# These compiler flags will not work on Windows
-add_library(geometry SHARED ${_sources})
+add_library(
+  geometry
+  SHARED
+  geometry_circle.f90
+  geometry_polygon.f90
+  geometry_rhombus.f90
+  geometry_square.f90
+  )
 
 add_executable(compute-areas compute-areas.f90)
+
+# These compiler flags will not work on Windows
 target_compile_options(geometry
   PRIVATE
     "-std=f2008"

--- a/chapter-01/recipe-10/cxx-example/CMakeLists.txt
+++ b/chapter-01/recipe-10/cxx-example/CMakeLists.txt
@@ -4,25 +4,42 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 # project name and language
 project(recipe-10 LANGUAGES CXX)
 
-# list sources by globbing
-file(GLOB _sources geometry_*)
-
-# try the IN LISTS foreach syntax
-message(STATUS "List sources using IN LISTS syntax")
-foreach(_source IN LISTS _sources)
-  get_filename_component(_tmp ${_source} NAME)
-  message(${_tmp})
-endforeach()
-# try the plain foreach syntax
-# requires to expand the contents of the variable
-message(STATUS "List sources using plain syntax")
-foreach(_source ${_sources})
-  get_filename_component(_tmp ${_source} NAME)
-  message(${_tmp})
-endforeach()
-
-add_library(geometry STATIC ${_sources})
-
 add_executable(compute-areas compute-areas.cpp)
+
+add_library(
+  geometry
+  STATIC
+  geometry_circle.cpp
+  geometry_circle.hpp
+  geometry_polygon.cpp
+  geometry_polygon.hpp
+  geometry_rhombus.cpp
+  geometry_rhombus.hpp
+  geometry_square.cpp
+  geometry_square.hpp
+  )
+
+# we wish to compile the library with the optimization flag: -O3
+target_compile_options(geometry
+  PRIVATE
+    -O3
+  )
+
+list(APPEND sources_with_lower_optimization geometry_circle.cpp geometry_rhombus.cpp)
+
+# we use the IN LISTS foreach syntax to set source properties
+message(STATUS "Setting source properties using IN LISTS syntax:")
+foreach(_source IN LISTS sources_with_lower_optimization)
+  set_source_files_properties(${_source} PROPERTIES COMPILE_FLAGS -O2)
+  message(STATUS "Appending -O2 flag for ${_source}")
+endforeach()
+
+# we demonstrate the plain foreach syntax to query source properties
+# requires to expand the contents of the variable
+message(STATUS "Querying sources properties using plain syntax:")
+foreach(_source ${sources_with_lower_optimization})
+  get_source_file_property(_flags ${_source} COMPILE_FLAGS)
+  message(STATUS "Source ${_source} has the following extra COMPILE_FLAGS: ${_flags}")
+endforeach()
 
 target_link_libraries(compute-areas geometry)


### PR DESCRIPTION
This PR consists of trivial changes plus a more significant one: The foreach recipe has been changed to not use glob but rather list all sources explicitly. The example now shows how to set and query extra compile flags for specific sources. The example shows how to lower optimization on certain sources. This could be done by defining a new target (and this will be discussed in the book) or the way it is demonstrated in the sources.