### PR TITLE
refactor gtest recipe; fixes #276

### DIFF
--- a/chapter-04/recipe-03/cxx-example-3.5/CMakeLists.txt
+++ b/chapter-04/recipe-03/cxx-example-3.5/CMakeLists.txt
@@ -1,5 +1,5 @@
 # set minimum cmake version
-cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 # project name and language
 project(recipe-03 LANGUAGES CXX)
@@ -21,28 +21,13 @@ target_link_libraries(sum_up sum_integers)
 option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
 message(STATUS "Enable testing: ${ENABLE_UNIT_TESTS}")
 
+include(googletest.cmake)
+
 if(ENABLE_UNIT_TESTS)
-  # the following code to fetch googletest
-  # is inspired by and adapted after:
-  #   - https://cmake.org/cmake/help/git-stage/module/FetchContent.html
-  include(FetchContent)
-
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        release-1.8.0
-  )
-
-  FetchContent_GetProperties(googletest)
-  if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-
-    # adds the targers: gtest, gtest_main, gmock, gmock_main
-    add_subdirectory(
-      ${googletest_SOURCE_DIR}
-      ${googletest_BINARY_DIR}
-      )
-  endif()
+  fetch_googletest(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest
+    )
 
   add_executable(cpp_test "")
 

--- a/chapter-04/recipe-03/cxx-example-3.5/googletest-download.cmake
+++ b/chapter-04/recipe-03/cxx-example-3.5/googletest-download.cmake
@@ -1,0 +1,20 @@
+# code copied from https://crascit.com/2015/07/25/cmake-gtest/
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(googletest-download LANGUAGES NONE)
+
+include(ExternalProject)
+
+ExternalProject_Add(
+  googletest
+  SOURCE_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-src"
+  BINARY_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-build"
+  GIT_REPOSITORY
+    https://github.com/google/googletest.git
+  GIT_TAG
+    release-1.8.0
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+  )

--- a/chapter-04/recipe-03/cxx-example-3.5/googletest.cmake
+++ b/chapter-04/recipe-03/cxx-example-3.5/googletest.cmake
@@ -1,0 +1,33 @@
+# download and unpack googletest at configure time
+
+# the following code to fetch googletest
+# is inspired by and adapted after https://crascit.com/2015/07/25/cmake-gtest/
+
+function(fetch_googletest _download_module_path _download_root)
+  set(GOOGLETEST_DOWNLOAD_ROOT ${_download_root})
+  configure_file(
+    ${_download_module_path}/googletest-download.cmake
+    ${_download_root}/CMakeLists.txt
+    @ONLY
+    )
+  unset(GOOGLETEST_DOWNLOAD_ROOT)
+
+  execute_process(
+    COMMAND
+      "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+    WORKING_DIRECTORY
+      ${_download_root}
+    )
+  execute_process(
+    COMMAND
+      "${CMAKE_COMMAND}" --build .
+    WORKING_DIRECTORY
+      ${_download_root}
+    )
+
+  # adds the targers: gtest, gtest_main, gmock, gmock_main
+  add_subdirectory(
+    ${_download_root}/googletest-src
+    ${_download_root}/googletest-build
+    )
+endfunction()

--- a/chapter-04/recipe-03/cxx-example-3.5/main.cpp
+++ b/chapter-04/recipe-03/cxx-example-3.5/main.cpp
@@ -1,0 +1,1 @@
+../../recipe-01/cxx-example/main.cpp

--- a/chapter-04/recipe-03/cxx-example-3.5/menu.yml
+++ b/chapter-04/recipe-03/cxx-example-3.5/menu.yml
@@ -1,0 +1,2 @@
+targets:
+  - test

--- a/chapter-04/recipe-03/cxx-example-3.5/sum_integers.cpp
+++ b/chapter-04/recipe-03/cxx-example-3.5/sum_integers.cpp
@@ -1,0 +1,1 @@
+../../recipe-01/cxx-example/sum_integers.cpp

--- a/chapter-04/recipe-03/cxx-example-3.5/sum_integers.hpp
+++ b/chapter-04/recipe-03/cxx-example-3.5/sum_integers.hpp
@@ -1,0 +1,1 @@
+../../recipe-01/cxx-example/sum_integers.hpp

--- a/chapter-04/recipe-03/cxx-example-3.5/test.cpp
+++ b/chapter-04/recipe-03/cxx-example-3.5/test.cpp
@@ -1,0 +1,1 @@
+../cxx-example/test.cpp


### PR DESCRIPTION
- Rewrote the 3.5 recipe following https://crascit.com/2015/07/25/cmake-gtest/
- Added a compact 3.11 version following https://cmake.org/cmake/help/git-stage/module/FetchContent.html

A lot of ugly hardcoding and duct tape is gone.