### PR TITLE
Fix ZeroMQ recipe on Visual Studio

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,12 +18,17 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       MSYSTEM: MINGW64
+      GENERATOR: "Visual Studio 14 2015 Win64"
+      BUILDFLAGS: "/verbosity:normal"
+      CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      MSYSTEM: MINGW64
       GENERATOR: "MSYS Makefiles"
       BUILDFLAGS: "VERBOSE=1"
       CMAKEARGS: ""
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       MSYSTEM: MINGW64
-      GENERATOR: "Visual Studio 14 2015"
+      GENERATOR: "Visual Studio 15 2017 Win64"
       BUILDFLAGS: "/verbosity:normal"
       CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -31,11 +36,6 @@ environment:
       GENERATOR: "Ninja"
       BUILDFLAGS: "-v"
       CMAKEARGS: ""
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      MSYSTEM: MINGW64
-      GENERATOR: "Visual Studio 15 2017"
-      BUILDFLAGS: "/verbosity:normal"
-      CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 install:
   - set PATH=C:\Python36;%PATH%
@@ -46,7 +46,7 @@ install:
   - '%APPVEYOR_BUILD_FOLDER%\testing\dependencies\appveyor\install.bat'
   - ps: .$env:APPVEYOR_BUILD_FOLDER\testing\dependencies\appveyor\install-msmpi.ps1
   - "SetEnvMPI.cmd"
-  - vcpkg install zeromq
+  - vcpkg install zeromq --triplet x64-windows
   - cd c:\tools\vcpkg
   - vcpkg integrate install
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,7 @@ install:
   - '%APPVEYOR_BUILD_FOLDER%\testing\dependencies\appveyor\install.bat'
   - ps: .$env:APPVEYOR_BUILD_FOLDER\testing\dependencies\appveyor\install-msmpi.ps1
   - "SetEnvMPI.cmd"
-  - vcpkg install zeromq --triplet x64-windows
+  - vcpkg install boost-filesystem boost-system boost-test boost-python zeromq --triplet x64-windows
   - cd c:\tools\vcpkg
   - vcpkg integrate install
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/chapter-01/recipe-01/fortran-example/menu.yml
+++ b/chapter-01/recipe-01/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-02/fortran-example/menu.yml
+++ b/chapter-01/recipe-02/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-03/fortran-example/menu.yml
+++ b/chapter-01/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-06/fortran-example/menu.yml
+++ b/chapter-01/recipe-06/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-07/fortran-example/menu.yml
+++ b/chapter-01/recipe-07/fortran-example/menu.yml
@@ -3,8 +3,8 @@ appveyor:
     - CMAKE_BUILD_TYPE: 'RelWithDebInfo'
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 drone:
   definitions:

--- a/chapter-01/recipe-09/fortran-example/menu.yml
+++ b/chapter-01/recipe-09/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 drone:
   definitions:

--- a/chapter-02/recipe-03/fortran-example/menu.yml
+++ b/chapter-02/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-04/cxx-example/menu.yml
+++ b/chapter-03/recipe-04/cxx-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-05/fortran-example-3.5/menu.yml
+++ b/chapter-03/recipe-05/fortran-example-3.5/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-05/fortran-example/menu.yml
+++ b/chapter-03/recipe-05/fortran-example/menu.yml
@@ -1,8 +1,8 @@
 appveyor:
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-06/c-example-3.5/menu.yml
+++ b/chapter-03/recipe-06/c-example-3.5/menu.yml
@@ -1,9 +1,9 @@
 appveyor:
   env:
-    - MSMPI_BIN: "C:\\Program Files\\Microsoft MPI\\Bin\\"
-    - MSMPI_INC: "C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"
-    - MSMPI_LIB32: "C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x86\\"
-    - MSMPI_LIB64: "'C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
+    - MSMPI_BIN: 'C:\Program Files\Microsoft MPI\Bin\'
+    - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
+    - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
+    - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-06/c-example/menu.yml
+++ b/chapter-03/recipe-06/c-example/menu.yml
@@ -1,9 +1,9 @@
 appveyor:
   env:
-    - MSMPI_BIN: "C:\\Program Files\\Microsoft MPI\\Bin\\"
-    - MSMPI_INC: "C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"
-    - MSMPI_LIB32: "C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x86\\"
-    - MSMPI_LIB64: "'C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
+    - MSMPI_BIN: 'C:\Program Files\Microsoft MPI\Bin\'
+    - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
+    - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
+    - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-06/cxx-example/menu.yml
+++ b/chapter-03/recipe-06/cxx-example/menu.yml
@@ -1,9 +1,9 @@
 appveyor:
   env:
-    - MSMPI_BIN: "C:\\Program Files\\Microsoft MPI\\Bin\\"
-    - MSMPI_INC: "C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"
-    - MSMPI_LIB32: "C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x86\\"
-    - MSMPI_LIB64: "'C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
+    - MSMPI_BIN: 'C:\Program Files\Microsoft MPI\Bin\'
+    - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
+    - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
+    - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-08/cxx-example/menu.yml
+++ b/chapter-03/recipe-08/cxx-example/menu.yml
@@ -1,6 +1,6 @@
 appveyor:
   env:
-    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
+    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 
 travis-osx:
   definitions:

--- a/chapter-03/recipe-08/cxx-example/menu.yml
+++ b/chapter-03/recipe-08/cxx-example/menu.yml
@@ -1,7 +1,6 @@
 appveyor:
   env:
-    - BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_66_0\lib64-msvc-14.0'
-    - BOOST_INCLUDEDIR: 'C:\Libraries\boost_1_66_0'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
 
 travis-osx:
   definitions:

--- a/chapter-03/recipe-09/c-example-3.5/menu.yml
+++ b/chapter-03/recipe-09/c-example-3.5/menu.yml
@@ -1,4 +1,4 @@
 appveyor:
   failing_generators:
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/c-example/menu.yml
+++ b/chapter-03/recipe-09/c-example/menu.yml
@@ -1,4 +1,4 @@
 appveyor:
   failing_generators:
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/cxx-uuid-example-3.5/menu.yml
+++ b/chapter-03/recipe-09/cxx-uuid-example-3.5/menu.yml
@@ -1,4 +1,4 @@
 appveyor:
   failing_generators:
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/cxx-uuid-example-3.5/menu.yml
+++ b/chapter-03/recipe-09/cxx-uuid-example-3.5/menu.yml
@@ -1,4 +1,6 @@
 appveyor:
   failing_generators:
+    - 'MSYS Makefiles'
+    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/cxx-uuid-example/menu.yml
+++ b/chapter-03/recipe-09/cxx-uuid-example/menu.yml
@@ -1,4 +1,4 @@
 appveyor:
   failing_generators:
-    - 'Visual Studio 14 2015'
-    - 'Visual Studio 15 2017'
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/cxx-uuid-example/menu.yml
+++ b/chapter-03/recipe-09/cxx-uuid-example/menu.yml
@@ -1,4 +1,6 @@
 appveyor:
   failing_generators:
+    - 'MSYS Makefiles'
+    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-10/c-example/FindZeroMQ.cmake
+++ b/chapter-03/recipe-10/c-example/FindZeroMQ.cmake
@@ -2,7 +2,7 @@
 # Adapted from: https://github.com/zeromq/azmq/blob/master/config/FindZeroMQ.cmake
 
 # Variables
-# ZMQ_ROOT - set this to a location where ZeroMQ may be found
+# ZeroMQ_ROOT - set this to a location where ZeroMQ may be found
 #
 # ZeroMQ_FOUND - True of ZeroMQ found
 # ZeroMQ_INCLUDE_DIRS - Location of ZeroMQ includes
@@ -10,14 +10,14 @@
 
 include(FindPackageHandleStandardArgs)
 
-if(NOT ZMQ_ROOT)
-  set(ZMQ_ROOT "$ENV{ZMQ_ROOT}")
+if(NOT ZeroMQ_ROOT)
+  set(ZeroMQ_ROOT "$ENV{ZeroMQ_ROOT}")
 endif()
 
-if(NOT ZMQ_ROOT)
+if(NOT ZeroMQ_ROOT)
   find_path(_ZeroMQ_ROOT NAMES include/zmq.h)
 else()
-  set(_ZeroMQ_ROOT "${ZMQ_ROOT}")
+  set(_ZeroMQ_ROOT "${ZeroMQ_ROOT}")
 endif()
 
 find_path(ZeroMQ_INCLUDE_DIRS NAMES zmq.h HINTS ${_ZeroMQ_ROOT}/include)
@@ -37,8 +37,6 @@ if(ZeroMQ_INCLUDE_DIRS)
   _zmqver_EXTRACT("ZMQ_VERSION_MINOR" ZeroMQ_VERSION_MINOR)
   _zmqver_EXTRACT("ZMQ_VERSION_PATCH" ZeroMQ_VERSION_PATCH)
 
-  message(STATUS "ZeroMQ version: ${ZeroMQ_VERSION_MAJOR}.${ZeroMQ_VERSION_MINOR}.${ZeroMQ_VERSION_PATCH}")
-
   # We should provide version to find_package_handle_standard_args in the same format as it was requested,
   # otherwise it can't check whether version matches exactly.
   if(ZeroMQ_FIND_VERSION_COUNT GREATER 2)
@@ -52,34 +50,37 @@ if(ZeroMQ_INCLUDE_DIRS)
   if(NOT ${CMAKE_C_PLATFORM_ID} STREQUAL "Windows")
     find_library(ZeroMQ_LIBRARIES NAMES zmq HINTS ${_ZeroMQ_ROOT}/lib)
   else()
-    find_library(
-        ZeroMQ_LIBRARY_RELEASE
+    find_library(ZeroMQ_LIBRARIES
         NAMES
           libzmq
+          "libzmq-mt-${ZeroMQ_VERSION_MAJOR}_${ZeroMQ_VERSION_MINOR}_${ZeroMQ_VERSION_PATCH}"
           "libzmq-${CMAKE_VS_PLATFORM_TOOLSET}-mt-${ZeroMQ_VERSION_MAJOR}_${ZeroMQ_VERSION_MINOR}_${ZeroMQ_VERSION_PATCH}"
+          libzmq_d
+          "libzmq-mt-gd-${ZeroMQ_VERSION_MAJOR}_${ZeroMQ_VERSION_MINOR}_${ZeroMQ_VERSION_PATCH}"
+          "libzmq-${CMAKE_VS_PLATFORM_TOOLSET}-mt-gd-${ZeroMQ_VERSION_MAJOR}_${ZeroMQ_VERSION_MINOR}_${ZeroMQ_VERSION_PATCH}"
         HINTS
           ${_ZeroMQ_ROOT}/lib
         )
-
-    find_library(
-        ZeroMQ_LIBRARY_DEBUG
-        NAMES
-          libzmq_d
-          "libzmq-${CMAKE_VS_PLATFORM_TOOLSET}-mt-gd-${ZeroMQ_VERSION_MAJOR}_${ZeroMQ_VERSION_MINOR}_${ZeroMQ_VERSION_PATCH}"
-        HINTS
-          ${_ZeroMQ_ROOT}/lib)
-
-    # On Windows we have to use corresponding version (i.e. Release or Debug) of ZeroMQ because of `errno` CRT global variable
-    # See more at http://www.drdobbs.com/avoiding-the-visual-c-runtime-library/184416623
-    set(ZeroMQ_LIBRARIES optimized "${ZeroMQ_LIBRARY_RELEASE}" debug "${ZeroMQ_LIBRARY_DEBUG}")
   endif()
 endif()
 
-find_package_handle_standard_args(ZeroMQ FOUND_VAR ZeroMQ_FOUND
-  REQUIRED_VARS ZeroMQ_INCLUDE_DIRS ZeroMQ_LIBRARIES
-  VERSION_VAR ZeroMQ_VERSION)
+find_package_handle_standard_args(ZeroMQ
+  FOUND_VAR
+    ZeroMQ_FOUND
+  REQUIRED_VARS
+    ZeroMQ_INCLUDE_DIRS
+    ZeroMQ_LIBRARIES
+  VERSION_VAR
+    ZeroMQ_VERSION
+  )
 
 if(ZeroMQ_FOUND)
-  mark_as_advanced(ZeroMQ_INCLUDE_DIRS ZeroMQ_LIBRARIES ZeroMQ_VERSION
-      ZeroMQ_VERSION_MAJOR ZeroMQ_VERSION_MINOR ZeroMQ_VERSION_PATCH)
+  mark_as_advanced(
+    ZeroMQ_INCLUDE_DIRS
+    ZeroMQ_LIBRARIES
+    ZeroMQ_VERSION
+    ZeroMQ_VERSION_MAJOR
+    ZeroMQ_VERSION_MINOR
+    ZeroMQ_VERSION_PATCH
+    )
 endif()

--- a/chapter-03/recipe-10/c-example/hwclient.c
+++ b/chapter-03/recipe-10/c-example/hwclient.c
@@ -4,7 +4,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <zmq.h>
 

--- a/chapter-03/recipe-10/c-example/hwserver.c
+++ b/chapter-03/recipe-10/c-example/hwserver.c
@@ -5,7 +5,12 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#if (_MSC_VER && !__INTEL_COMPILER)
+#include <WinSock2.h>
+#include <Windows.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <zmq.h>
 
@@ -25,7 +30,11 @@ int main(void) {
     char buffer[10];
     zmq_recv(responder, buffer, 10, 0);
     printf("Received Hello\n");
+#if (_MSC_VER && !__INTEL_COMPILER)
+    Sleep(1*1000); //  Do some 'work'
+#else
     sleep(1); //  Do some 'work'
+#endif
     zmq_send(responder, "World", 5, 0);
   }
   return 0;

--- a/chapter-03/recipe-10/c-example/menu.yml
+++ b/chapter-03/recipe-10/c-example/menu.yml
@@ -1,0 +1,3 @@
+appveyor:
+  definitions:
+    - ZeroMQ_ROOT: 'c:\tools\vcpkg\installed\x64-windows'

--- a/chapter-04/recipe-01/cxx-example/menu.yml
+++ b/chapter-04/recipe-01/cxx-example/menu.yml
@@ -1,6 +1,6 @@
 appveyor:
   env:
-    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
+    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 
 targets:
   - test

--- a/chapter-04/recipe-01/cxx-example/menu.yml
+++ b/chapter-04/recipe-01/cxx-example/menu.yml
@@ -1,7 +1,6 @@
 appveyor:
   env:
-    - BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_66_0\lib64-msvc-14.0'
-    - BOOST_INCLUDEDIR: 'C:\Libraries\boost_1_66_0\boost'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
 
 targets:
   - test

--- a/chapter-04/recipe-03/cxx-example-3.5/googletest.cmake
+++ b/chapter-04/recipe-03/cxx-example-3.5/googletest.cmake
@@ -37,4 +37,14 @@ function(fetch_googletest _download_module_path _download_root)
     ${_download_root}/googletest-src
     ${_download_root}/googletest-build
     )
+
+  # Silence std::tr1 warning on MSVC
+  if(MSVC)
+    foreach(_tgt gtest gtest_main gmock gmock_main)
+      target_compile_definitions(${_tgt}
+        PRIVATE
+          "_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING"
+        )
+    endforeach()
+  endif()
 endfunction()

--- a/chapter-04/recipe-03/cxx-example/CMakeLists.txt
+++ b/chapter-04/recipe-03/cxx-example/CMakeLists.txt
@@ -50,6 +50,16 @@ if(ENABLE_UNIT_TESTS)
       ${googletest_SOURCE_DIR}
       ${googletest_BINARY_DIR}
       )
+
+    # Silence std::tr1 warning on MSVC
+    if(MSVC)
+      foreach(_tgt gtest gtest_main gmock gmock_main)
+        target_compile_definitions(${_tgt}
+          PRIVATE
+            "_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING"
+          )
+      endforeach()
+    endif()
   endif()
 
   add_executable(cpp_test "")

--- a/chapter-04/recipe-04/cxx-example/menu.yml
+++ b/chapter-04/recipe-04/cxx-example/menu.yml
@@ -1,6 +1,6 @@
 appveyor:
   env:
-    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
+    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 
 travis-osx:
   definitions:

--- a/chapter-04/recipe-04/cxx-example/menu.yml
+++ b/chapter-04/recipe-04/cxx-example/menu.yml
@@ -1,8 +1,6 @@
 appveyor:
   env:
     - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
-    - BOOST_INCLUDEDIR: 'C:\Libraries\boost_1_66_0'
-    - BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_66_0\lib64-msvc-14.0'
 
 travis-osx:
   definitions:

--- a/chapter-09/recipe-04/cxx-example/menu.yml
+++ b/chapter-09/recipe-04/cxx-example/menu.yml
@@ -1,6 +1,6 @@
 appveyor:
   env:
-    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
+    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 
 travis-osx:
   definitions:

--- a/chapter-09/recipe-04/cxx-example/menu.yml
+++ b/chapter-09/recipe-04/cxx-example/menu.yml
@@ -1,7 +1,6 @@
 appveyor:
   env:
-    - BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_66_0\lib64-msvc-14.0'
-    - BOOST_INCLUDEDIR: 'C:\Libraries\boost_1_66_0\boost'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_66_0'
 
 travis-osx:
   definitions:


### PR DESCRIPTION
## Description
Mainly fixes the ZeroMQ example (chapter 3, recipe 10) with VS generator.

## Todos
- [x] Interleave generators on AppVeyor (VS, MSYS, VS, MSYS)
- [x] Run Visual Studio first, because it takes longer
- [x] Visual Studio generator is 64bit
- [x] Fix FindZeroMQ.cmake to find library installed via VcPkg
- [x] Fix ZeroMQ example so that it compiles also on Windows
- [x] Install Boost components we use (filesystem, python, test) using VcPkg. Fixes Boost detection :confetti_ball: 
- [x] Properly set MS-MPI environment. Fixes MPI recipe with VS :confetti_ball:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
