### PR TITLE
Less if/endif, use compiler name/id directly

### DIFF
--- a/chapter-02/recipe-03/cxx-example/CMakeLists.txt
+++ b/chapter-02/recipe-03/cxx-example/CMakeLists.txt
@@ -7,6 +7,8 @@ project(recipe-03 LANGUAGES CXX)
 # define executable and its source file
 add_executable(hello-world hello-world.cpp)
 
+target_compile_definitions(hello-world PUBLIC "-DCOMPILER_NAME=\"${CMAKE_CXX_COMPILER_ID}\"")
+
 # let the preprocessor know about the compiler vendor
 if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
   target_compile_definitions(hello-world PUBLIC "-DIS_INTEL_CXX_COMPILER")

--- a/chapter-02/recipe-03/cxx-example/hello-world.cpp
+++ b/chapter-02/recipe-03/cxx-example/hello-world.cpp
@@ -23,5 +23,6 @@ std::string say_hello() {
 
 int main() {
   std::cout << say_hello() << std::endl;
+  std::cout << "compiler name is " COMPILER_NAME << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is a simple alternative suggestion to show that one can use CMake variable value directly
by using it as preprocessor value as well.

This is not really meant to be merged as-is, but may be you'll find a way to show both approaches?
